### PR TITLE
feat: support other containers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id("xyz.jpenilla.run-paper") version "2.3.1"
+    id("com.gradleup.shadow") version "8.3.6"
 }
 
 group = 'me.sxigames'
@@ -20,6 +21,7 @@ repositories {
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    implementation("org.bstats:bstats-bukkit:3.0.0")
 }
 
 tasks {
@@ -29,6 +31,14 @@ tasks {
         // Your plugin's jar (or shadowJar if present) will be used automatically.
         minecraftVersion("1.21.4")
     }
+    shadowJar {
+        minimize()
+        relocate("org.bstats", "me.sxigames.bstats")
+    }
+    build {
+        dependsOn(shadowJar)
+    }
+
 }
 
 def targetJavaVersion = 21

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'me.sxigames'
-version = '0.0.3a'
+version = '0.1.0b'
 
 repositories {
     mavenCentral()

--- a/src/main/java/me/sxigames/liftChest/LiftChest.java
+++ b/src/main/java/me/sxigames/liftChest/LiftChest.java
@@ -2,6 +2,7 @@ package me.sxigames.liftChest;
 
 import me.sxigames.liftChest.events.*;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bstats.bukkit.Metrics;
 
 public final class LiftChest extends JavaPlugin {
 
@@ -14,6 +15,7 @@ public final class LiftChest extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new playerMove(), this);
         getServer().getPluginManager().registerEvents(new playerQuit(), this);
         getServer().getPluginManager().registerEvents(new playerChangeWorld(), this);
+        Metrics metrics = new Metrics(this, 25431);
     }
 
     @Override

--- a/src/main/java/me/sxigames/liftChest/events/playerPlaceBlock.java
+++ b/src/main/java/me/sxigames/liftChest/events/playerPlaceBlock.java
@@ -6,8 +6,8 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Block;
-import org.bukkit.block.Chest;
-import org.bukkit.entity.ItemDisplay;
+import org.bukkit.block.Container;
+import org.bukkit.block.Furnace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -24,28 +24,30 @@ public class playerPlaceBlock implements Listener {
     public void onBlockPlace(BlockPlaceEvent event) {
         Block block = event.getBlock();
         Player player = event.getPlayer();
-        if(block.getType() == Material.STONE_BUTTON && player.getScoreboardTags().contains("carrying")){
+        if(block.getState() instanceof Container container && player.getScoreboardTags().contains("carrying")){
             player.getPassengers().forEach((passenger) -> {
-                if (passenger.getScoreboardTags().contains("carried") && passenger instanceof ItemDisplay itemDisplay) {
+                if (passenger.getScoreboardTags().contains("carried")) {
                     Plugin plugin = LiftChest.getPlugin();
-                    block.setType(itemDisplay.getItemStack().getType());
-                    org.bukkit.block.data.type.Chest chestData = (org.bukkit.block.data.type.Chest) block.getBlockData();
-                    chestData.setType(org.bukkit.block.data.type.Chest.Type.SINGLE);
-                    chestData.setFacing(player.getFacing().getOppositeFace());
-                    block.setBlockData(chestData);
-                    NamespacedKey chestKey = new NamespacedKey(plugin, "chestData");
-                    ItemStack[] items = ItemStack.deserializeItemsFromBytes(Objects.requireNonNull(passenger.getPersistentDataContainer().get(chestKey, PersistentDataType.BYTE_ARRAY)));
+                    NamespacedKey inventoryKey = new NamespacedKey(plugin, "inventoryBytes");
+                    ItemStack[] items = ItemStack.deserializeItemsFromBytes(Objects.requireNonNull(passenger.getPersistentDataContainer().get(inventoryKey, PersistentDataType.BYTE_ARRAY)));
                     PlayerInventory inventory = player.getInventory();
                     inventory.setItemInMainHand(ItemStack.of(Material.AIR));
                     inventory.setItemInOffHand(ItemStack.of(Material.AIR));
-                    Chest chestState = (Chest) block.getState();
-                    NamespacedKey chestNameKey = new NamespacedKey(plugin, "chestName");
-                    if (passenger.getPersistentDataContainer().has(chestNameKey, PersistentDataType.STRING)){
-                        String chestName = Objects.requireNonNull(passenger.getPersistentDataContainer().get(chestNameKey, PersistentDataType.STRING));
-                        chestState.customName(MiniMessage.miniMessage().deserialize(chestName));
-                        chestState.update();
+                    NamespacedKey containerNameKey = new NamespacedKey(plugin, "containerName");
+                    if (passenger.getPersistentDataContainer().has(containerNameKey, PersistentDataType.STRING)){
+                        String containerName = Objects.requireNonNull(passenger.getPersistentDataContainer().get(containerNameKey, PersistentDataType.STRING));
+                        container.customName(MiniMessage.miniMessage().deserialize(containerName));
                     }
-                    chestState.getBlockInventory().setStorageContents(items);
+                    else {
+                        container.customName(null);
+                    }
+                    if (container instanceof Furnace furnace){
+                        NamespacedKey burnTimeKey = new NamespacedKey(plugin, "burnTime");
+                        short burnTime = Objects.requireNonNull(passenger.getPersistentDataContainer().get(burnTimeKey, PersistentDataType.SHORT));
+                        furnace.setBurnTime(burnTime);
+                    }
+                    container.update();
+                    container.getInventory().setStorageContents(items);
                     passenger.remove();
                     player.removeScoreboardTag("carrying");
                     NamespacedKey slowKey = new NamespacedKey(plugin, "carryingSlow");

--- a/src/main/java/me/sxigames/liftChest/events/playerQuit.java
+++ b/src/main/java/me/sxigames/liftChest/events/playerQuit.java
@@ -3,7 +3,6 @@ package me.sxigames.liftChest.events;
 import io.papermc.paper.event.player.PlayerClientLoadedWorldEvent;
 import me.sxigames.liftChest.LiftChest;
 import net.kyori.adventure.text.Component;
-import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.ItemDisplay;
@@ -43,13 +42,15 @@ public class playerQuit implements Listener {
             assert itemDisplay != null;
             itemDisplay.setVisibleByDefault(true);
             player.addPassenger(itemDisplay);
-            ItemStack button = ItemStack.of(Material.STONE_BUTTON);
-            button.editMeta(itemMeta -> {
+            ItemStack handItem = itemDisplay.getItemStack();
+            NamespacedKey airModel = new NamespacedKey("minecraft", "air");
+            handItem.editMeta(itemMeta -> {
                 itemMeta.customName(Component.text("lifting"));
                 itemMeta.addEnchant(Enchantment.VANISHING_CURSE, 1, true);
+                itemMeta.setItemModel(airModel);
             });
-            player.getInventory().setItemInMainHand(button);
-            player.getInventory().setItemInOffHand(button);
+            player.getInventory().setItemInMainHand(handItem);
+            player.getInventory().setItemInOffHand(handItem);
         }
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: LiftChest
-version: '0.0.3a'
+version: '0.1.0b'
 author: Sxigames
 main: me.sxigames.liftChest.LiftChest
 api-version: '1.21'


### PR DESCRIPTION
This pull request includes several changes to the `LiftChest` plugin to improve functionality and add new features. The most important changes include updating the plugin to use a more generic `Container` class, adding support for tracking additional container types, and updating the plugin version.

### Improvements to functionality:

* [`src/main/java/me/sxigames/liftChest/LiftChest.java`](diffhunk://#diff-ec59fbc43110c99bcb9520cd85efb22ca7268cbcdb184afeb83f5b0f509350a1R5): Added `Metrics` to track plugin usage statistics. [[1]](diffhunk://#diff-ec59fbc43110c99bcb9520cd85efb22ca7268cbcdb184afeb83f5b0f509350a1R5) [[2]](diffhunk://#diff-ec59fbc43110c99bcb9520cd85efb22ca7268cbcdb184afeb83f5b0f509350a1R18)

### Support for additional container types:

* [`src/main/java/me/sxigames/liftChest/events/playerInteract.java`](diffhunk://#diff-d775c0c71e830230c43248d661459c119c32304b255641d8f847ca2967c3b2d6L10-R10): Updated the `onPlayerInteract` method to handle any `Container` instead of just `Chest`, and added support for tracking `Furnace` burn time. [[1]](diffhunk://#diff-d775c0c71e830230c43248d661459c119c32304b255641d8f847ca2967c3b2d6L10-R10) [[2]](diffhunk://#diff-d775c0c71e830230c43248d661459c119c32304b255641d8f847ca2967c3b2d6L41-R82)
* [`src/main/java/me/sxigames/liftChest/events/playerPlaceBlock.java`](diffhunk://#diff-9547eed202ffe8c5b310e68dc0739842036615bc2e79120aab26e394908e0adeL9-R10): Updated the `onBlockPlace` method to handle any `Container` and added support for restoring `Furnace` burn time. [[1]](diffhunk://#diff-9547eed202ffe8c5b310e68dc0739842036615bc2e79120aab26e394908e0adeL9-R10) [[2]](diffhunk://#diff-9547eed202ffe8c5b310e68dc0739842036615bc2e79120aab26e394908e0adeL27-R50)

### Codebase simplification:

* [`src/main/java/me/sxigames/liftChest/events/playerQuit.java`](diffhunk://#diff-909fa43bd337286aa937e4e698fe2f3afdaefa9295d9e57c91cc4d541895ea73L6): Simplified the code by removing unnecessary imports and updating item handling. [[1]](diffhunk://#diff-909fa43bd337286aa937e4e698fe2f3afdaefa9295d9e57c91cc4d541895ea73L6) [[2]](diffhunk://#diff-909fa43bd337286aa937e4e698fe2f3afdaefa9295d9e57c91cc4d541895ea73L46-R53)

### Version update:

* [`src/main/resources/plugin.yml`](diffhunk://#diff-98201effe40eaf4a0e8826fadd6c5c9d5beaf9d737226b514f0853f44987a67fL2-R2): Updated the plugin version to `0.1.0b`.